### PR TITLE
Fixed Prototype pollution in ptree

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -146,6 +146,9 @@ class PTree {
     set(key, value) {
         const segments = getSegments(key);
         let obj = this.root;
+        if(segments.includes('__proto__') || segments.includes('constructor') || segments.includes('prototype')){
+            return undefined;
+        }
         for (let i = 0; i < segments.length; i++) {
             const current = obj;
             const seg = segments[i];

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,11 @@ export default class PTree {
 
     // Iterative deep object descent & set
     let obj = this.root;
+    
+    // Prototype pollution mitigation
+    if(segments.includes('__proto__') || segments.includes('constructor') || segments.includes('prototype')){
+      return undefined;
+    }
 
     for (let i = 0; i < segments.length; i++) {
       const current = obj;


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40dotvirus%2Fptree/

### ⚙️ Description *

`@dotvirus/ptree` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `segments` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
// poc.js
const ptree = require('@dotvirus/ptree').default

console.log('Before: ' + {}.polluted)
const tree = new ptree({})
tree.set('__proto__.polluted', true)
console.log('After: ' + {}.polluted)
```


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.


### 👍 User Acceptance Testing (UAT)

Tests run, all ok.
Just prevented some keywords as `keys` and no breaking changes are introduced. :)
