### PR TITLE
Disallow prototype path override by checking magic attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,18 @@ const pm = require("picomatch");
 
 export type Key = string | number | (() => string | number);
 
+const ILLEGAL_KEYS = new Set(["prototype", "constructor", "__proto__"]);
+
+function isIllegalKey(key: string): Boolean {
+  return ILLEGAL_KEYS.has(key);
+}
+
+function disallowProtopath(key: string | number): void {
+  if (typeof key === "string" && isIllegalKey(key)) {
+    throw new Error("Unsafe key encountered: " + key)
+  }
+}
+
 function getSegments(path: Key | Key[]): (string | number)[] {
   let segments = [];
   if (typeof path === "string") {
@@ -180,6 +192,7 @@ export default class PTree {
     for (let i = 0; i < segments.length; i++) {
       const current = obj;
       const seg = segments[i];
+      disallowProtopath(seg);
 
       if (i < segments.length - 1) {
         obj = (<any>obj)[seg];

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 let $p = require("../dist/").default;
+const assert = require("assert")
 
 function compare(actual, expected) {
   console.log(
@@ -607,3 +608,15 @@ const obj25 = {
 compare($p.from(obj25).wildcard("a.*").length, 2);
 compare($p.from(obj25).wildcard("b.**").length, 4);
 compare($p.from(obj25).wildcard("d.*").length, 0);
+
+function isProtoPathPolluted() {
+  const t = new $p({});
+  t.set('__proto__.polluted', true)
+}
+
+function testProtoPathPollution() {
+  assert.throws(isProtoPathPolluted, "Test failed for Proto Path.")
+  console.log("Test passed.")
+}
+
+testProtoPathPollution();


### PR DESCRIPTION
### 📊 Metadata *

@dotvirus/ptree is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40dotvirus%2Fptree/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


    Create the following PoC file:

```
// poc.js
const ptree = require('@dotvirus/ptree').default

console.log('Before: ' + {}.polluted)
const tree = new ptree({})
tree.set('__proto__.polluted', true)
console.log('After: ' + {}.polluted)
```

    Execute the following commands in the terminal:

```
npm i @dotvirus/ptree # install vulnerable package
node poc.js # run the PoC
```

    Check the output:

```
Before: undefined
After: true
```


### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106096265-368c1380-615b-11eb-887b-65b2ae681a5b.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106096328-5a4f5980-615b-11eb-9093-e739e823b0d7.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106097426-4d336a00-615d-11eb-81a4-1e0f4bb2d17d.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1800
